### PR TITLE
Introduce enlargedImagePosition prop (for desktop only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ import { ReactImageMagnifyTouch } from 'react-image-magnify';
 | `hoverDelayInMs`              | Number | No       | 250     | Milliseconds to delay hover trigger.                       |
 | `hoverOffDelayInMs`           | Number | No       | 150     | Milliseconds to delay hover-off trigger.                   |
 | `lensStyle`                   | Object | No       |         | Style applied to tinted lens.                      |
+| `enlargedImagePosition`       | String | No       | beside  | Enlarged image position. Can be 'beside' or 'over'.        |
 
 ### Touch Only
 | Prop                          | Type   | Required | Default | Description                                                |

--- a/src/EnlargedImage.js
+++ b/src/EnlargedImage.js
@@ -46,7 +46,8 @@ export default React.createClass({
         isHovering: PropTypes.bool,
         isRenderOnDemand: PropTypes.bool,
         largeImage: ImageShape,
-        smallImage: ImageShape
+        smallImage: ImageShape,
+        imagePosition: PropTypes.string
     },
 
     componentWillReceiveProps(nextProps) {
@@ -93,6 +94,7 @@ export default React.createClass({
             isRenderOnDemand,
             largeImage,
             smallImage,
+            imagePosition
         } = this.props;
 
         const {
@@ -130,14 +132,31 @@ export default React.createClass({
             isVisible = false;
         }
 
-        const defaultContainerStyle = {
-            marginLeft: '10px',
+        let imgDataHover;
+        let defaultContainerStyle = {
             position: 'absolute',
-            left: '100%',
             top: '0px',
             border: '1px solid #d6d6d6',
             overflow: 'hidden'
         };
+        
+        switch (imagePosition) {
+        case 'over':
+            imgDataHover = true;
+            defaultContainerStyle = Object.assign({}, defaultContainerStyle, {
+                left: '0px'                    
+            });
+            break;
+            
+        case 'beside':
+        default:
+            imgDataHover = false;
+            defaultContainerStyle = Object.assign({}, defaultContainerStyle, {
+                marginLeft: '10px',
+                left: '100%'
+            });
+            break;
+        }
 
         const computedContainerStyle = {
             width: smallImage.width,
@@ -162,7 +181,7 @@ export default React.createClass({
                 key: 'enlarged',
                 style: Object.assign({}, defaultContainerStyle, containerStyle, computedContainerStyle)
             }}>
-                <img data-hover="false" { ...{
+                <img data-hover={imgDataHover} { ...{
                     alt: largeImage.alt,
                     className: imageClassName,
                     src: largeImage.src,

--- a/src/ReactImageMagnify.js
+++ b/src/ReactImageMagnify.js
@@ -21,14 +21,31 @@ const ReactImageMagnify = ({
     largeImage,
     lensStyle,
     smallImage,
-    style
+    style,
+    enlargedImagePosition
 }) => {
 
     const cursorOffset = {
         x: Math.round(((smallImage.width / largeImage.width) * smallImage.width) / 2),
         y: Math.round(((smallImage.height / largeImage.height) * smallImage.height) / 2)
     };
-    const defaultLensStyle = { backgroundColor: 'rgba(0,0,0,.4)' };
+    
+    let defaultLensStyle = {};
+    
+    switch (enlargedImagePosition) {
+    case 'over':
+        defaultLensStyle = Object.assign({}, defaultLensStyle, {
+        });
+        break;
+        
+    case 'beside':
+    default:
+        defaultLensStyle = Object.assign({}, defaultLensStyle, {
+            backgroundColor: 'rgba(0,0,0,.4)'
+        });
+        break;
+    }
+    
     const compositLensStyle = Object.assign({}, defaultLensStyle, lensStyle);
 
     return (
@@ -95,6 +112,7 @@ const ReactImageMagnify = ({
                     imageStyle: enlargedImageStyle,
                     largeImage,
                     smallImage,
+                    imagePosition: enlargedImagePosition
                 }}/>
             </ReactHoverObserver>
         </ReactCursorPosition>
@@ -123,13 +141,15 @@ ReactImageMagnify.propTypes = {
     largeImage: ImageShape,
     lensStyle: PropTypes.object,
     smallImage: ImageShape,
-    style: PropTypes.object
+    style: PropTypes.object,
+    enlargedImagePosition: PropTypes.string
 };
 
 ReactImageMagnify.defaultProps = {
     fadeDurationInMs: 300,
     hoverDelayInMs: 250,
-    hoverOffDelayInMs: 150
+    hoverOffDelayInMs: 150,
+    enlargedImagePosition: 'beside'
 };
 
 export default ReactImageMagnify;

--- a/test/enlarged-image.spec.js
+++ b/test/enlarged-image.spec.js
@@ -65,7 +65,8 @@ describe('Enlarged Image', () => {
             isHovering: PropTypes.bool,
             isRenderOnDemand: PropTypes.bool,
             largeImage: ImageShape,
-            smallImage: ImageShape
+            smallImage: ImageShape,
+            imagePosition: PropTypes.string
         });
     });
 
@@ -119,6 +120,12 @@ describe('Enlarged Image', () => {
             const renderedWrapper = shallowWrapper.render();
 
             expect(renderedWrapper.find('img').css('border')).to.equal(borderValue);
+        });
+
+        it('applies imagePosition to image', () => {
+            const renderedWrapper = shallowWrapper.render();
+
+            expect(renderedWrapper.find('img').data('hover')).to.be.false;
         });
 
         it('applies large image alt', () => {
@@ -238,7 +245,7 @@ describe('Enlarged Image', () => {
         });
 
         it('applies default style', () => {
-            const expected = 'margin-left:10px;position:absolute;left:100%;top:0px;border:1px solid #d6d6d6;overflow:hidden;';
+            const expected = 'position:absolute;top:0px;border:1px solid #d6d6d6;overflow:hidden;';
 
             const renderedWrapper = shallowWrapper.render();
 

--- a/test/react-image-magnify.spec.js
+++ b/test/react-image-magnify.spec.js
@@ -48,7 +48,8 @@ describe('React Image Magnify', () => {
             largeImage: ImageShape,
             lensStyle: PropTypes.object,
             smallImage: ImageShape,
-            style: PropTypes.object
+            style: PropTypes.object,
+            enlargedImagePosition: PropTypes.string
         });
     });
 
@@ -56,7 +57,8 @@ describe('React Image Magnify', () => {
         expect(ReactImageMagnify.defaultProps).to.deep.equal({
             fadeDurationInMs: 300,
             hoverDelayInMs: 250,
-            hoverOffDelayInMs: 150
+            hoverOffDelayInMs: 150,
+            enlargedImagePosition: 'beside'
         });
     });
 
@@ -172,6 +174,12 @@ describe('React Image Magnify', () => {
 
         it('applies largeImage to EnlargedImage element', () => {
             expect(shallowWrapper.find('EnlargedImage').props().largeImage).to.equal(largeImage);
+        });   
+
+        it('applies enlargedImagePosition to EnlargedImage element', () => {
+            shallowWrapper.setProps({ enlargedImagePosition: 'over' });
+
+            expect(shallowWrapper.find('EnlargedImage').props().imagePosition).to.equal('over');
         });
     });
 });


### PR DESCRIPTION
Hello @ethanselzer 
I just add optional prop **enlargedImagePosition** to choose position of enlarged image : 
- **beside** (default) : same behavior
- **over** : enlarged image will be over the small image

Have a nice day :)
